### PR TITLE
Remove :where from *::before, *::after

### DIFF
--- a/package/index.css
+++ b/package/index.css
@@ -1,4 +1,4 @@
-:where(*, *::before, *::after) {
+*, *::before, *::after {
 	margin: 0;
 	padding: 0;
 	box-sizing: border-box;


### PR DESCRIPTION
Pseudo-elements such as `::before` and `::after` won't work inside `:where` function. And to prevent duplicates of the same code, I removed `*` from `:where` as well.