### PR TITLE
remove height from `html`/`body`

### DIFF
--- a/package/index.css
+++ b/package/index.css
@@ -15,12 +15,6 @@
 	color-scheme: dark light;
 }
 
-@supports not (min-block-size: 100dvb) {
-	:where(html) {
-		block-size: 100%;
-	}
-}
-
 @media (prefers-reduced-motion: no-preference) {
 	:where(html:focus-within) {
 		scroll-behavior: smooth;
@@ -28,8 +22,6 @@
 }
 
 :where(body) {
-	block-size: 100%;
-	block-size: 100dvb;
 	line-height: 1.5;
 	font-family: system-ui, sans-serif;
 	-webkit-font-smoothing: antialiased;


### PR DESCRIPTION
yeeted because it gets in the way very often, plus there is good `dvb` support so the weird fallback is not needed.