### PR TITLE
remove `.not-visually-hidden` class

### DIFF
--- a/package/README.md
+++ b/package/README.md
@@ -58,7 +58,7 @@ Every project needs "visually hidden" styles for screenreader-only text, so this
 
 It's available through the `.visually-hidden` class and all the rules in it use `!important` so that they can't be overridden by a higher-priority layer.
 
-When a visually-hidden element is focused or an element inside it is focused, then these styles will automatically be undone. Additionally, a `.not-visually-hidden` class is available to undo these styles on some other condition.
+When a visually-hidden element is focused or an element inside it is focused, then these styles will automatically be undone.
 
 ### Focus outlines
 

--- a/package/index.css
+++ b/package/index.css
@@ -99,7 +99,7 @@
 	outline-offset: 2px;
 }
 
-:where(.visually-hidden:not(:focus, :active, :focus-within, .not-visually-hidden)) {
+:where(.visually-hidden:not(:focus-within, :active)) {
 	clip-path: inset(50%) !important;
 	height: 1px !important;
 	width: 1px !important;


### PR DESCRIPTION
in most cases where it's useful, it requires JS to toggle. but if JS is being used already, might as well toggle the `visually-hidden` class instead.

also removed `:focus` because `:focus-within` already includes focus on the same element