### PR TITLE
remove `--focus-color` variable and increase outline-width

### DIFF
--- a/package/README.md
+++ b/package/README.md
@@ -62,7 +62,16 @@ When a visually-hidden element is focused or an element inside it is focused, th
 
 ### Focus outlines
 
-By default, focus styles can be very inconsistent (and even inaccessible) across browsers. This reset normalizes them to a 2px solid outline that has the [`Highlight`](https://www.w3.org/TR/css-color-4/#system-color-values) color. You can modify this using the `--focus-color` custom property (you might want it to match your accent color).
+By default, focus styles can be very inconsistent (and even inaccessible) across browsers. This reset normalizes them to a 3px solid outline that has the [`Highlight`](https://www.w3.org/TR/css-color-4/#system-color-values) color. The is a system color that adopts with the `color-scheme`. Depending on the background within a particular section, you might want to set the `color-scheme` property to maintain enough color contrast.
+
+To override the focus styles, you can specify your own `outline` (or just `outline-color`).
+```
+@layer globals {
+  :focus-visible {
+    outline-color: var(--my-brand);
+  }
+}
+```
 
 ## Acknowledgements
 

--- a/package/index.css
+++ b/package/index.css
@@ -95,7 +95,7 @@
 }
 
 :where(:focus-visible) {
-	outline: 2px solid var(--focus-color, Highlight);
+	outline: 3px solid Highlight;
 	outline-offset: 2px;
 }
 


### PR DESCRIPTION
it's trivial to override the `outline-color`, so this variable is not necessary at all.

also increased outline width to 3px so its more obvious

together with #7, this reduces the api surface of this stylesheet to just the `.visually-hidden` class (which is common and intuitive enough to not need docs)