### PR TITLE
add scroll-margin for focused elements

### DIFF
--- a/package/index.css
+++ b/package/index.css
@@ -97,7 +97,7 @@
 :where(:focus-visible) {
 	outline: 2px solid var(--focus-color, Highlight);
 	outline-offset: 2px;
-	scroll-margin-block-start: 8rem;
+	scroll-margin-block: 8rem;
 }
 
 :where(.visually-hidden:not(:focus, :active, :focus-within, .not-visually-hidden)) {

--- a/package/index.css
+++ b/package/index.css
@@ -97,7 +97,7 @@
 :where(:focus-visible) {
 	outline: 2px solid var(--focus-color, Highlight);
 	outline-offset: 2px;
-	scroll-margin-block: min(10vh, 7rem);
+	scroll-margin-block: 10vh;
 }
 
 :where(.visually-hidden:not(:focus, :active, :focus-within, .not-visually-hidden)) {

--- a/package/index.css
+++ b/package/index.css
@@ -97,6 +97,7 @@
 :where(:focus-visible) {
 	outline: 2px solid var(--focus-color, Highlight);
 	outline-offset: 2px;
+	scroll-margin-block-start: 10rem;
 }
 
 :where(.visually-hidden:not(:focus, :active, :focus-within, .not-visually-hidden)) {

--- a/package/index.css
+++ b/package/index.css
@@ -97,7 +97,7 @@
 :where(:focus-visible) {
 	outline: 2px solid var(--focus-color, Highlight);
 	outline-offset: 2px;
-	scroll-margin-block-start: 10rem;
+	scroll-margin-block-start: 8rem;
 }
 
 :where(.visually-hidden:not(:focus, :active, :focus-within, .not-visually-hidden)) {

--- a/package/index.css
+++ b/package/index.css
@@ -97,7 +97,7 @@
 :where(:focus-visible) {
 	outline: 2px solid var(--focus-color, Highlight);
 	outline-offset: 2px;
-	scroll-margin-block: 8rem;
+	scroll-margin-block: min(10vh, 7rem);
 }
 
 :where(.visually-hidden:not(:focus, :active, :focus-within, .not-visually-hidden)) {


### PR DESCRIPTION
see https://www.tpgi.com/prevent-focused-elements-from-being-obscured-by-sticky-headers/

(supported in safari 15, article is outdated)

applies scroll-margin on _both_ ends so the focused element is in a more convenient spot. this is nice even in the absence of sticky headers/bottombars.

the value is debatable, but it will never be more than 10% of the viewport height, so i feel it's an ok default.