### PR TITLE
add `text-wrap: balance` to main headings

### DIFF
--- a/package/index.css
+++ b/package/index.css
@@ -77,6 +77,7 @@
 
 :where(h1, h2, h3) {
 	line-height: calc(1em + 0.5rem);
+	text-wrap: balance;
 }
 
 :where(hr) {


### PR DESCRIPTION
it is generally a good idea to default `h1, h2, h3` to `text-wrap: balance;`.

arguably, it could be applied to all heading levels but let's start with this.