### PR TITLE
add missing max-width for `video`

### DIFF
--- a/package/index.css
+++ b/package/index.css
@@ -66,7 +66,7 @@
 	display: block;
 }
 
-:where(img, picture, svg) {
+:where(img, picture, svg, video) {
 	max-inline-size: 100%;
 	block-size: auto;
 }


### PR DESCRIPTION
why should only images have all the fun?