### PR TITLE
use dual focus indicator

### DIFF
--- a/package/index.css
+++ b/package/index.css
@@ -89,8 +89,9 @@
 }
 
 :where(:focus-visible) {
-	outline: 3px solid Highlight;
-	outline-offset: 2px;
+	outline: 3px solid CanvasText;
+	box-shadow: 0 0 0 5px Canvas;
+	outline-offset: 1px;
 	scroll-margin-block: 10vh;
 }
 


### PR DESCRIPTION
the readme claims "Accessible, consistent focus outlines."

this is actually not true, as different browsers have a different idea of what `Highlight` entails. moreover, even within browsers that do have a consistent idea of `Highlight`, they will not be perfect alone if the background doesn't have enough contrast.

a dual `Canvas`+`CanvasText` focus indicator works more consistently and has a better chance of being always accessible. it will always adapt to the `color-scheme` (`light` or `dark`) and will also have maximum contrast. basically the 3px `CanvasText` outline is surrounded by a 1px `Canvas` shadow on both sides, avoiding contrast issues with the element's background or the page background.

<img width="86" alt="image" src="https://github.com/mayank99/reset.css/assets/9084735/19d1b11c-d6e6-44b9-9432-e9e04afa8376">
<img width="78" alt="image" src="https://github.com/mayank99/reset.css/assets/9084735/4042916a-266f-4ff1-b5b3-a03cc934673e">
<img width="91" alt="image" src="https://github.com/mayank99/reset.css/assets/9084735/a3c65592-274b-454c-8825-6ae933c5875e">
<img width="81" alt="image" src="https://github.com/mayank99/reset.css/assets/9084735/980ce9d3-1c8b-417b-9329-5d4a27b5a5e9">

combined, these styles should pass WCAG SC 1.4.11, 2.4.7, 2.4.12, 2.4.13 in most cases

i initially didn't want to use `box-shadow` because many elements bring their own box-shadow. *but* with the current appraoch, the `outline` is always present, so we have a "fallback" of sorts, even if the `box-shadow` gets removed by the developer or in forced-colors.