### PR TITLE
reset dialog styles

### DIFF
--- a/package/index.css
+++ b/package/index.css
@@ -97,6 +97,8 @@
 	border: none;
 	background: none;
 	inset: unset;
+	max-width: unset;
+	max-height: unset;
 }
 
 :where(dialog:not([open])) {

--- a/package/index.css
+++ b/package/index.css
@@ -16,6 +16,10 @@
 	tab-size: 2;
 }
 
+:where(html:has(dialog:modal[open])) {
+	overflow: clip;
+}
+
 @media (prefers-reduced-motion: no-preference) {
 	:where(html:focus-within) {
 		scroll-behavior: smooth;
@@ -87,6 +91,16 @@
 	color: inherit;
 	block-size: 0;
 	overflow: visible;
+}
+
+:where(dialog) {
+	border: none;
+	background: none;
+	inset: unset;
+}
+
+:where(dialog:not([open])) {
+	display: none !important;
 }
 
 :where(:focus-visible) {

--- a/package/index.css
+++ b/package/index.css
@@ -14,6 +14,7 @@
 	-webkit-text-size-adjust: none;
 	color-scheme: dark light;
 	tab-size: 2;
+	scrollbar-gutter: stable;
 }
 
 :where(html:has(dialog:modal[open])) {


### PR DESCRIPTION
- removes scrollbar when page is not scrollable
- unsets positioning, since the default positioning relies on auto `margin`
- removes weird background/border
- removes weird max-width/max-height that is based on `content-box`
- reinforces hidden-ness of dialog when closed