### PR TITLE
add resets for `popover`

### DIFF
--- a/package/index.css
+++ b/package/index.css
@@ -102,7 +102,18 @@
 	max-height: unset;
 }
 
-:where(dialog:not([open])) {
+:where(dialog:not([open], [popover])) {
+	display: none !important;
+}
+
+:where([popover]) {
+	border: none;
+	background: none;
+	inset: unset;
+	color: inherit;
+}
+
+:where([popover]:not(:popover-open)) {
 	display: none !important;
 }
 


### PR DESCRIPTION
- removes weird colors and positioning from `popover`
- ensures it stays hidden when popover is not open
- handles `<dialog popover>`